### PR TITLE
Updated readme to reflect Mac OSX dependencies

### DIFF
--- a/README
+++ b/README
@@ -24,6 +24,9 @@ version of python, you need to get access to simplejson and httplib2.
 You can get simplejson from http://pypi.python.org/pypi/simplejson/
 and httplib2 from http://code.google.com/p/httplib2/.
 
+If you're installing fish on Mac OSX using python 2.7 you might also need to manually install httplib2.
+The simplest way to install it is to first install pip by issuing 'sudo easy_install pip' in terminal.
+Then to install httplib2 enter 'pip install httplib2'.  
 
 CREDENTIALS
 ===========


### PR DESCRIPTION
Expanded the readme to provide mac specific details for handling the httplib2 since it is not necessarily installed by default even for versions of python greater than 2.6.
